### PR TITLE
SPARQL expansion: PD subclass tree + CC-license query (A1, A2, B5)

### DIFF
--- a/scripts/config.php
+++ b/scripts/config.php
@@ -74,6 +74,32 @@ class WikiStreamConfigWikiFlix extends WikiStreamConfig
 			FILTER(?percent>=60 && ?percent<=150) # that is similar to the item duration
 			?q wdt:P577 ?date . FILTER (year(?date)<=1928) # 1928 or earlier
 		}",
+		# Films licensed under any Creative Commons licence except CC-*-ND.
+		# A film qualifies when at least one P275 statement points to a CC
+		# licence (instance of Q284742). The ND exclusion is dynamic: any
+		# P275 value whose English label contains "noderiv" disqualifies
+		# the film, which covers BY-ND and BY-NC-ND across all versions
+		# and jurisdictional variants without needing a hand-maintained
+		# Q-ID list. CC-*-NC variants are intentionally allowed.
+		"SELECT DISTINCT ?q {
+			?q (wdt:P31/(wdt:P279*)) wd:Q11424 ; # A film
+			   wdt:P275 ?lic .                   # with a licence claim
+			?lic wdt:P31 wd:Q284742 .            # licence is a Creative Commons licence
+			MINUS { ?q wdt:P31 wd:Q97570383 } # Glass positive
+			MINUS {
+				?q wdt:P275 ?nd_lic .
+				?nd_lic rdfs:label ?nd_label .
+				FILTER(LANG(?nd_label) = \"en\")
+				FILTER(CONTAINS(LCASE(?nd_label), \"noderiv\"))
+			}
+			OPTIONAL { ?q wdt:P724 ?ia }
+			OPTIONAL { ?q wdt:P10 ?commons }
+			OPTIONAL { ?q wdt:P1651 ?youtube }
+			OPTIONAL { ?q wdt:P4015 ?vimeo }
+			OPTIONAL { ?q wdt:P11731 ?dailymotion }
+			BIND(BOUND(?ia)||BOUND(?commons)||BOUND(?youtube)||BOUND(?vimeo)||BOUND(?dailymotion) as ?hasMedia)
+			FILTER(?hasMedia=true)
+		}",
 	];
 	public $people_props = [161, 57];
 	public $misc_section_props = [31, 166, 136, 462, 495, 364, 361];

--- a/scripts/config.php
+++ b/scripts/config.php
@@ -42,7 +42,11 @@ class WikiStreamConfigWikiFlix extends WikiStreamConfig
 	public $bad_genres = [185529, 4373044, 3461143, 599558]; # P136
 	public $sparql = [
 		"SELECT DISTINCT ?q {
-			?q (wdt:P31/(wdt:P279*)) wd:Q11424 ; wdt:P6216 wd:Q19652 .
+			?q (wdt:P31/(wdt:P279*)) wd:Q11424 ; wdt:P6216/(wdt:P279*) wd:Q19652 .
+			# P279* below Q19652 also catches PD-equivalent subclasses
+			# like Q88088423 (copyrighted, dedicated to the public domain
+			# by copyright holder). The base case wdt:P6216 wd:Q19652 is
+			# still matched because P279* allows zero hops.
 			MINUS { ?q wdt:P31 wd:Q97570383 } # Glass positive
 			OPTIONAL { ?q wdt:P724 ?ia }
 			OPTIONAL { ?q wdt:P10 ?commons }

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -60,6 +60,38 @@ final class ConfigTest extends TestCase
         }
     }
 
+    /**
+     * A1: Query #1 must walk the P279 subclass tree below Q19652 so that
+     * P6216 values like Q88088423 ("copyrighted, dedicated to the public
+     * domain by copyright holder") and any future PD-equivalent subclass
+     * are also matched. The hard-coded `wdt:P6216 wd:Q19652` only matched
+     * the exact item.
+     */
+    public function test_wikiflix_query1_uses_p6216_subclass_path(): void
+    {
+        $config = new \WikiStreamConfigWikiFlix();
+        $query1 = $config->sparql[0];
+
+        $this->assertMatchesRegularExpression(
+            '/wdt:P6216\s*\/\s*\(?\s*wdt:P279\*\s*\)?\s+wd:Q19652/',
+            $query1,
+            'Query #1 must traverse P279* below Q19652 (e.g. wdt:P6216/wdt:P279* wd:Q19652).'
+        );
+    }
+
+    /**
+     * A1: the change must not weaken existing filters — the film P31
+     * subclass walk and the glass-positive MINUS must still be present.
+     */
+    public function test_wikiflix_query1_keeps_film_filter_and_glass_minus(): void
+    {
+        $config = new \WikiStreamConfigWikiFlix();
+        $query1 = $config->sparql[0];
+
+        $this->assertStringContainsString('wd:Q11424', $query1, 'Film class Q11424 must remain in query #1.');
+        $this->assertStringContainsString('Q97570383', $query1, 'Glass-positive exclusion must remain in query #1.');
+    }
+
     public function test_wikiflix_bad_genres_are_integers(): void
     {
         $config = new \WikiStreamConfigWikiFlix();

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -92,6 +92,37 @@ final class ConfigTest extends TestCase
         $this->assertStringContainsString('Q97570383', $query1, 'Glass-positive exclusion must remain in query #1.');
     }
 
+    /**
+     * A2: a fourth SPARQL query must catch films released under any
+     * Creative Commons licence (P275 → instance of Q284742) except for
+     * any CC-*-ND variant. The ND exclusion is done dynamically via a
+     * label-contains-"noderiv" filter to remain robust against new
+     * jurisdictional ND variants being added to Wikidata.
+     */
+    public function test_wikiflix_has_cc_license_query(): void
+    {
+        $config = new \WikiStreamConfigWikiFlix();
+
+        $this->assertGreaterThanOrEqual(
+            4,
+            count($config->sparql),
+            'WikiFlix must have a fourth SPARQL query for CC-licensed films.'
+        );
+
+        $query = $config->sparql[3];
+
+        $this->assertStringContainsString('wdt:P275', $query, 'CC-license query must filter on P275.');
+        $this->assertStringContainsString('wd:Q284742', $query, 'CC-license query must require the P275 value to be a Creative Commons license (Q284742).');
+        $this->assertStringContainsString('wd:Q11424', $query, 'CC-license query must restrict to films (Q11424).');
+        $this->assertMatchesRegularExpression(
+            '/noderiv/i',
+            $query,
+            'CC-license query must exclude NoDerivatives variants.'
+        );
+        // Same media-availability shape as query #1
+        $this->assertStringContainsString('hasMedia', $query, 'CC-license query must use the hasMedia filter shape.');
+    }
+
     public function test_wikiflix_bad_genres_are_integers(): void
     {
         $config = new \WikiStreamConfigWikiFlix();

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -66,6 +66,8 @@ final class ConfigTest extends TestCase
      * domain by copyright holder") and any future PD-equivalent subclass
      * are also matched. The hard-coded `wdt:P6216 wd:Q19652` only matched
      * the exact item.
+     *
+     * @return void
      */
     public function test_wikiflix_query1_uses_p6216_subclass_path(): void
     {
@@ -82,6 +84,8 @@ final class ConfigTest extends TestCase
     /**
      * A1: the change must not weaken existing filters — the film P31
      * subclass walk and the glass-positive MINUS must still be present.
+     *
+     * @return void
      */
     public function test_wikiflix_query1_keeps_film_filter_and_glass_minus(): void
     {
@@ -98,6 +102,8 @@ final class ConfigTest extends TestCase
      * any CC-*-ND variant. The ND exclusion is done dynamically via a
      * label-contains-"noderiv" filter to remain robust against new
      * jurisdictional ND variants being added to Wikidata.
+     *
+     * @return void
      */
     public function test_wikiflix_has_cc_license_query(): void
     {
@@ -119,7 +125,7 @@ final class ConfigTest extends TestCase
             $query,
             'CC-license query must exclude NoDerivatives variants.'
         );
-        // Same media-availability shape as query #1
+        // Same media-availability shape as query #1.
         $this->assertStringContainsString('hasMedia', $query, 'CC-license query must use the hasMedia filter shape.');
     }
 

--- a/tests/unit/WikiStreamTest.php
+++ b/tests/unit/WikiStreamTest.php
@@ -1145,21 +1145,27 @@ final class WikiStreamTest extends TestCase
      */
     private function makeFileClaim(string $key, bool $optOut = false): object
     {
-        $c = new \stdClass();
-        $c->mainsnak = new \stdClass();
-        $c->mainsnak->datavalue = new \stdClass();
-        $c->mainsnak->datavalue->value = $key;
-        $c->mainsnak->datavalue->type = 'string';
+        $claim = new \stdClass();
+        $claim->mainsnak = new \stdClass();
+        $claim->mainsnak->datavalue = new \stdClass();
+        $claim->mainsnak->datavalue->value = $key;
+        $claim->mainsnak->datavalue->type = 'string';
         if ($optOut) {
-            $c->qualifiers = new \stdClass();
+            $claim->qualifiers = new \stdClass();
             $qual = new \stdClass();
             $qual->datavalue = new \stdClass();
             $qual->datavalue->value = (object) ['id' => 'Q124428688'];
-            $c->qualifiers->P11484 = [$qual];
+            $claim->qualifiers->P11484 = [$qual];
         }
-        return $c;
+        return $claim;
     }
 
+    /**
+     * `$ws` matches the file-wide convention for the WikiStream-under-test
+     * variable; suppress PHPMD's ShortVariable rule for this method only.
+     *
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
     public function test_p11484_opt_out_applies_to_all_file_props(): void
     {
         [$ws] = $this->makeWikiStream();
@@ -1176,6 +1182,9 @@ final class WikiStreamTest extends TestCase
             11731 => [$this->makeFileClaim('optedout-dm-id', optOut: true)],
         ];
 
+        // Only getClaims is overridden; the bootstrap stub's defaults
+        // (empty label, empty sitelinks, empty getFirstString/getTarget)
+        // are sufficient for the opt-out code path we're exercising.
         $item = new class($claims) extends \WikidataItem {
             private array $claimsByProp;
             public function __construct(array $claimsByProp)
@@ -1188,10 +1197,6 @@ final class WikiStreamTest extends TestCase
                 $key = (int) preg_replace('/\D/', '', (string) $prop);
                 return $this->claimsByProp[$key] ?? [];
             }
-            public function getLabel(string $lang = 'en'): string { return 'Test Film'; }
-            public function getSitelinks(): array { return []; }
-            public function getFirstString(string $prop): string { return ''; }
-            public function getTarget(object $claim): string { return ''; }
         };
 
         $wil = new \WikidataItemList();
@@ -1200,19 +1205,17 @@ final class WikiStreamTest extends TestCase
         $qs = [];
         $sections = [];
         $entry_files = [];
-        $items_for_labels = []; // array form so add_item_details defers labels
+        $items_for_labels = []; // array form so add_item_details defers labels.
         $item_rows = [];
 
-        // add_item_details is protected and takes references. Use a closure
-        // bound to the instance so PHP threads the by-reference args through
-        // without reflection's invokeArgs limitations.
-        $invoke = \Closure::bind(
-            function ($wil, $q, &$qs, &$sections, &$entry_files, &$items_for_labels, &$item_rows) {
-                $this->add_item_details($wil, $q, $qs, $sections, $entry_files, $items_for_labels, $item_rows);
-            },
-            $ws,
-            \WikiStream::class,
-        );
+        // add_item_details is protected and takes references. bindTo() (the
+        // instance form of Closure::bind) lets the closure see protected
+        // methods while keeping by-reference args working — reflection's
+        // invokeArgs cannot pass references through.
+        $invoke = function ($wil, $q, &$qs, &$sections, &$entry_files, &$items_for_labels, &$item_rows) {
+            $this->add_item_details($wil, $q, $qs, $sections, $entry_files, $items_for_labels, $item_rows);
+        };
+        $invoke = $invoke->bindTo($ws, \WikiStream::class);
         $invoke($wil, 42, $qs, $sections, $entry_files, $items_for_labels, $item_rows);
 
         // Clean files for every property are kept; opted-out keys are dropped.

--- a/tests/unit/WikiStreamTest.php
+++ b/tests/unit/WikiStreamTest.php
@@ -1131,4 +1131,100 @@ final class WikiStreamTest extends TestCase
 
         $this->assertCount(0, $ws->capturedCommands);
     }
+
+    // ------------------------------------------------------------------
+    // B5: the P11484 "do not use for WikiFlix" qualifier (value
+    // Q124428688) must suppress file ingestion for ANY property in
+    // $config->file_props — not just P10 / P724. Regression test
+    // protects the universal opt-out behaviour at add_item_details.
+    // ------------------------------------------------------------------
+
+    /**
+     * Build a Wikidata claim object with a string mainsnak value and an
+     * optional P11484 opt-out qualifier.
+     */
+    private function makeFileClaim(string $key, bool $optOut = false): object
+    {
+        $c = new \stdClass();
+        $c->mainsnak = new \stdClass();
+        $c->mainsnak->datavalue = new \stdClass();
+        $c->mainsnak->datavalue->value = $key;
+        $c->mainsnak->datavalue->type = 'string';
+        if ($optOut) {
+            $c->qualifiers = new \stdClass();
+            $qual = new \stdClass();
+            $qual->datavalue = new \stdClass();
+            $qual->datavalue->value = (object) ['id' => 'Q124428688'];
+            $c->qualifiers->P11484 = [$qual];
+        }
+        return $c;
+    }
+
+    public function test_p11484_opt_out_applies_to_all_file_props(): void
+    {
+        [$ws] = $this->makeWikiStream();
+
+        // One claim per file property; mix opted-out and clean.
+        $claims = [
+            10    => [
+                $this->makeFileClaim('Clean-Commons.webm'),
+                $this->makeFileClaim('OptedOut-Commons.webm', optOut: true),
+            ],
+            724   => [$this->makeFileClaim('clean-ia-id')],
+            1651  => [$this->makeFileClaim('optedout-yt-id', optOut: true)],
+            4015  => [$this->makeFileClaim('clean-vimeo-id')],
+            11731 => [$this->makeFileClaim('optedout-dm-id', optOut: true)],
+        ];
+
+        $item = new class($claims) extends \WikidataItem {
+            private array $claimsByProp;
+            public function __construct(array $claimsByProp)
+            {
+                parent::__construct((object) ['id' => 'Q42']);
+                $this->claimsByProp = $claimsByProp;
+            }
+            public function getClaims(string|int $prop): array
+            {
+                $key = (int) preg_replace('/\D/', '', (string) $prop);
+                return $this->claimsByProp[$key] ?? [];
+            }
+            public function getLabel(string $lang = 'en'): string { return 'Test Film'; }
+            public function getSitelinks(): array { return []; }
+            public function getFirstString(string $prop): string { return ''; }
+            public function getTarget(object $claim): string { return ''; }
+        };
+
+        $wil = new \WikidataItemList();
+        $wil->setItem(42, $item);
+
+        $qs = [];
+        $sections = [];
+        $entry_files = [];
+        $items_for_labels = []; // array form so add_item_details defers labels
+        $item_rows = [];
+
+        // add_item_details is protected and takes references. Use a closure
+        // bound to the instance so PHP threads the by-reference args through
+        // without reflection's invokeArgs limitations.
+        $invoke = \Closure::bind(
+            function ($wil, $q, &$qs, &$sections, &$entry_files, &$items_for_labels, &$item_rows) {
+                $this->add_item_details($wil, $q, $qs, $sections, $entry_files, $items_for_labels, $item_rows);
+            },
+            $ws,
+            \WikiStream::class,
+        );
+        $invoke($wil, 42, $qs, $sections, $entry_files, $items_for_labels, $item_rows);
+
+        // Clean files for every property are kept; opted-out keys are dropped.
+        $joined = implode("\n", $entry_files);
+        $this->assertStringContainsString('Clean-Commons.webm', $joined, 'Clean P10 file must be kept.');
+        $this->assertStringContainsString('clean-ia-id', $joined, 'Clean P724 file must be kept.');
+        $this->assertStringContainsString('clean-vimeo-id', $joined, 'Clean P4015 file must be kept.');
+
+        $this->assertStringNotContainsString('OptedOut-Commons.webm', $joined, 'P10 opt-out must filter the file.');
+        $this->assertStringNotContainsString('optedout-yt-id', $joined, 'P1651 opt-out must filter the file.');
+        $this->assertStringNotContainsString('optedout-dm-id', $joined, 'P11731 opt-out must filter the file.');
+
+        $this->assertCount(3, $entry_files, 'Exactly 3 clean files (one per non-opted-out claim) must be ingested.');
+    }
 }


### PR DESCRIPTION
## Summary

First of three PRs implementing the WikiFlix \"find more eligible movies\" audit.
Three commits, all pure SPARQL / config / test changes — no new runtime code paths, no Wikidata writes.

- **A1** — Query #1 now walks `wdt:P6216/(wdt:P279*) wd:Q19652` so PD-equivalent subclasses (e.g. `Q88088423` \"copyrighted, dedicated to the public domain by copyright holder\") are also matched. Empirically a strict superset on live Wikidata (34,133 vs. 34,129 films).
- **A2** — New fourth SPARQL query for films licensed under any Creative Commons licence (`P275` → instance of `Q284742`) except CC-*-ND variants. ND exclusion is dynamic via a `CONTAINS(LCASE(?label),\"noderiv\")` filter covering all ~45 jurisdictional ND Q-IDs without a hand-maintained list. CC-*-NC variants are intentionally allowed per the open-licence policy (\"not CC-*-ND\", not \"must be non-commercial\"). Empirical impact: 127 additional candidate films.
- **B5** — Regression test pinning the universal `P11484=Q124428688` opt-out behaviour. The audit claimed the opt-out only applied to P10/P724; investigation showed it is in fact applied uniformly across every property in `\$config->file_props`. This test guards that.

## Skipped from the audit

- **B4 (P9586 PeerTube):** P9586 is actually \"Apple TV Movie ID\" (a paid streaming service) — my audit was wrong. There is no Wikidata property for PeerTube video IDs (PeerTube is federated). B4 dropped.
- **Query #2 ND fix:** per user direction, query #2's lack of explicit ND filter is left as-is.

## Constraint compliance

- **Don't exclude films currently included** — A1 is a strict SPARQL superset (verified by live count). A2 is purely additive (a fourth query, OR'd with the others via `INSERT IGNORE`). B5 adds no new exclusions. ✓
- **Except ND-licensed:** A2 explicitly excludes ND; no other change touches ND handling. ✓

## Test plan

- [x] `vendor/bin/phpunit` — 130 tests, 249 assertions, all green
- [x] Live SPARQL validation on `query.wikidata.org` (A1 and A2 queries parse and return results)
- [ ] After merge: observe one cron run of `scripts/update.php` (default pipeline) and confirm new items appear without errors in `wikiflix_p`