### PR TITLE
Local ingestion: P953 URL promotion + IA curated-collection bypass (A4, A5)

### DIFF
--- a/scripts/update.php
+++ b/scripts/update.php
@@ -28,6 +28,8 @@ match ($cmd) {
 	'import_ia_curated_imdb_p724' => $ws->import_ia_curated_imdb_p724(),
 	'import_commons_pd_films_via_p180' => $ws->import_commons_pd_films_via_p180(),
 	'import_commons_video_minutes' => $ws->import_commons_video_minutes(),
+	'import_p953_urls'          => $ws->import_p953_urls(),
+	'import_ia_curated_films'   => $ws->import_ia_curated_films(),
 	'update_item_no_files'      => $ws->update_item_no_files_search_results(),
 	'reset'                     => null, // already handled above
 	default                     => (function() use ($ws) {
@@ -54,6 +56,8 @@ match ($cmd) {
 		$ws->annotate_pre_1900_public_domain();
 		$ws->import_ia_curated_imdb_p724();
 		$ws->import_commons_pd_films_via_p180();
+		$ws->import_p953_urls();
+		$ws->import_ia_curated_films();
 
 		# Might run out of memory so run this last
 		$ws->generate_all_data();

--- a/scripts/wikistream.php
+++ b/scripts/wikistream.php
@@ -74,6 +74,28 @@ class WikiStream
 	 */
 	public const C2_VIDEO_EXTENSIONS = ['webm', 'ogv', 'ogg', 'mp4'];
 
+	/**
+	 * Maximum number of QuickStatements add-statement commands the
+	 * import_p953_urls() bot will emit per cron invocation. Bounds bot
+	 * activity on the first runs through a large candidate backlog.
+	 */
+	public const P953_COMMANDS_PER_RUN = 100;
+
+	/**
+	 * Maximum number of IA candidate films import_ia_curated_films() will
+	 * fetch metadata for per cron invocation. Each candidate is one HTTP
+	 * request to archive.org/metadata; this caps that fan-out.
+	 */
+	public const IA_CURATED_CANDIDATES_PER_RUN = 200;
+
+	/**
+	 * IA collection slugs that are considered curated enough to skip the
+	 * 60–150 % duration-agreement filter used by SPARQL query #3. Films
+	 * whose IA item is in any of these collections are accepted on the
+	 * strength of the collection's own curation.
+	 */
+	public const IA_CURATED_COLLECTIONS = ['feature_films', 'silent_films', 'prelinger'];
+
 	public $tfc;
 	public $language = "en";
 	public $config;
@@ -1564,6 +1586,287 @@ class WikiStream
 		require_once $qs_lib;
 		$qs = $this->tfc->getQS($this->config->toolkey, __DIR__ . "/../bot.ini");
 		$this->tfc->runCommandsQS($commands, $qs);
+	}
+
+	/**
+	 * Ingest films whose IA P724 item belongs to a curated whitelist
+	 * collection (see self::IA_CURATED_COLLECTIONS), bypassing the
+	 * 60–150 % duration-agreement filter used by SPARQL query #3.
+	 *
+	 * Query #3 keeps working unchanged — this method is additive: any
+	 * film already accepted by query #3 still is, and films newly added
+	 * here are the ones query #3 rejected for duration or year reasons.
+	 *
+	 * Network cost is bounded by self::IA_CURATED_CANDIDATES_PER_RUN.
+	 * The Wikidata items themselves are merely INSERTed into `item`
+	 * (with available=0) — the normal pipeline picks them up on the
+	 * next pass to fetch file/section claims.
+	 */
+	public function import_ia_curated_films(): void
+	{
+		$sparql =
+			"SELECT DISTINCT ?q ?ia WHERE {
+				?q (wdt:P31/(wdt:P279*)) wd:Q11424 ;
+				   wdt:P2047 ?duration .
+				?q p:P724 ?statement .
+				MINUS { ?statement pq:P11484 wd:Q124428688 } .
+				?statement ps:P724 ?ia .
+				?statement pq:P2047 ?ia_duration .
+				MINUS { ?q wdt:P31 wd:Q97570383 }
+			}";
+
+		// q (int) → ia identifier (string). Cap candidate count before
+		// HTTP fan-out to bound load on the IA metadata API.
+		$candidates = [];
+		foreach ($this->tfc->getSPARQL_TSV($sparql) as $row) {
+			if (count($candidates) >= self::IA_CURATED_CANDIDATES_PER_RUN) {
+				break;
+			}
+			$q = $this->tfc->parseItemFromURL((string) ($row["q"] ?? ""));
+			$q_numeric = (int) preg_replace("|\D|", "", (string) $q);
+			$ia = (string) ($row["ia"] ?? "");
+			if ($q_numeric > 0 && $ia !== "") {
+				$candidates[$q_numeric] = $ia;
+			}
+		}
+		if (count($candidates) === 0) {
+			return;
+		}
+
+		// Drop candidates that are already in the items table; the cron
+		// pipeline will pick those up the normal way.
+		$existing = $this->get_items_in_db();
+		foreach ($candidates as $q_numeric => $_ia) {
+			if (isset($existing["Q{$q_numeric}"])) {
+				unset($candidates[$q_numeric]);
+			}
+		}
+		if (count($candidates) === 0) {
+			return;
+		}
+
+		// Batch IA metadata fetches in chunks of 50.
+		$accepted = [];
+		foreach (array_chunk($candidates, 50, true) as $chunk) {
+			$urls = [];
+			foreach ($chunk as $q_numeric => $ia) {
+				$urls[$q_numeric] = "https://archive.org/metadata/" . rawurlencode($ia);
+			}
+			$responses = $this->httpClient->getJsonBatch($urls);
+			foreach ($chunk as $q_numeric => $_ia) {
+				$j = $responses[$q_numeric] ?? null;
+				if (!isset($j)) {
+					continue;
+				}
+				if (isset($j->is_dark) && $j->is_dark) {
+					continue;
+				}
+				$collection = $j->metadata->collection ?? null;
+				if ($collection === null) {
+					continue;
+				}
+				// Normalise to array: IA returns a string when an item is
+				// in exactly one collection and a list otherwise.
+				if (is_string($collection)) {
+					$collection = [$collection];
+				}
+				if (!is_array($collection)) {
+					continue;
+				}
+				$matches = array_intersect(self::IA_CURATED_COLLECTIONS, $collection);
+				if (count($matches) > 0) {
+					$accepted[] = $q_numeric;
+				}
+			}
+		}
+
+		if (count($accepted) === 0) {
+			return;
+		}
+
+		// Insert in chunks. INSERT IGNORE handles races against the
+		// normal SPARQL pipeline writing the same q in parallel.
+		foreach (array_chunk($accepted, 500) as $chunk) {
+			$sql =
+				"INSERT IGNORE INTO `item` (`q`) VALUES (" .
+				implode("),(", $chunk) .
+				")";
+			$this->tfc->getSQL($this->db, $sql);
+		}
+	}
+
+	/**
+	 * Promote wdt:P953 ("full work available at URL") values into the
+	 * native host-specific properties (P10/P724/P1651/P4015/P11731) via
+	 * QuickStatements, so the regular ingestion pipeline picks them up
+	 * on the next cron run.
+	 *
+	 * Targets films that have at least one P953 statement but none of the
+	 * supported host properties. Statements carrying the
+	 * P11484=Q124428688 ("do not use for WikiFlix") opt-out qualifier or
+	 * a deprecated rank are skipped. Bot activity is capped at
+	 * self::P953_COMMANDS_PER_RUN commands per invocation.
+	 */
+	public function import_p953_urls(): void
+	{
+		$sparql =
+			"SELECT DISTINCT ?q WHERE {
+				?q (wdt:P31/(wdt:P279*)) wd:Q11424 ;
+				   wdt:P953 ?url .
+				MINUS { ?q wdt:P10 ?_c }
+				MINUS { ?q wdt:P724 ?_i }
+				MINUS { ?q wdt:P1651 ?_y }
+				MINUS { ?q wdt:P4015 ?_v }
+				MINUS { ?q wdt:P11731 ?_d }
+				MINUS { ?q wdt:P31 wd:Q97570383 }
+			}";
+
+		$candidate_qs = [];
+		foreach ($this->tfc->getSPARQL_TSV($sparql) as $row) {
+			$q = $this->tfc->parseItemFromURL((string) ($row["q"] ?? ""));
+			$q_numeric = (int) preg_replace("|\D|", "", (string) $q);
+			if ($q_numeric > 0) {
+				$candidate_qs[] = $q_numeric;
+			}
+		}
+		if (count($candidate_qs) === 0) {
+			return;
+		}
+		$candidate_qs = array_values(array_unique($candidate_qs));
+
+		$wil = $this->loadWikidataItemList($candidate_qs);
+
+		$commands = [];
+		foreach ($candidate_qs as $q_numeric) {
+			if (count($commands) >= self::P953_COMMANDS_PER_RUN) {
+				break;
+			}
+			$item = $wil->getItem($q_numeric);
+			if (!isset($item)) {
+				continue;
+			}
+			foreach ($item->getClaims("P953") as $claim) {
+				if (count($commands) >= self::P953_COMMANDS_PER_RUN) {
+					break;
+				}
+				if (isset($claim->rank) && $claim->rank === "deprecated") {
+					continue;
+				}
+				if (!isset($claim->mainsnak->datavalue->value)) {
+					continue;
+				}
+				$value = $claim->mainsnak->datavalue->value;
+				if (!is_string($value)) {
+					continue;
+				}
+
+				// Honour the same opt-out qualifier the file ingester respects.
+				if (isset($claim->qualifiers->P11484)) {
+					$opted_out = false;
+					foreach ($claim->qualifiers->P11484 as $qual) {
+						if (($qual->datavalue->value->id ?? "") === self::WD_DO_NOT_USE) {
+							$opted_out = true;
+							break;
+						}
+					}
+					if ($opted_out) {
+						continue;
+					}
+				}
+
+				$parsed = self::parseP953Url($value);
+				if ($parsed === null) {
+					continue;
+				}
+				[$prop, $key] = $parsed;
+				$key_safe = addslashes($key);
+				$commands[] = "Q{$q_numeric}\tP{$prop}\t\"{$key_safe}\"\t/* Imported from P953 URL */";
+			}
+		}
+
+		$this->pushQuickStatements($commands);
+	}
+
+	/**
+	 * Parse a URL appearing in a wdt:P953 (full work available at URL) claim
+	 * and identify the WikiFlix file-host property + key it should yield.
+	 *
+	 * Returns [property_id, key] for known hosts, or null when the URL does
+	 * not map to one of the supported video hosts. Used by import_p953_urls()
+	 * to queue QuickStatements add-statement commands that promote the
+	 * generic P953 link into the native host-specific property
+	 * (P10/P724/P1651/P4015/P11731), which the rest of the pipeline already
+	 * understands.
+	 *
+	 * Pure function, no side effects — kept testable in isolation.
+	 *
+	 * @return array{int,string}|null
+	 */
+	public static function parseP953Url(string $url): ?array
+	{
+		$url = trim($url);
+		if ($url === "") {
+			return null;
+		}
+		$parts = parse_url($url);
+		if (!is_array($parts) || !isset($parts["host"])) {
+			return null;
+		}
+		$host = strtolower($parts["host"]);
+		$path = ltrim($parts["path"] ?? "", "/");
+
+		// Internet Archive → P724 (only /details/<id> form is a watch page)
+		if (preg_match('~^(?:www\.)?archive\.org$~', $host)) {
+			if (preg_match('~^details/([^/?#]+)~', $path, $m)) {
+				return [724, $m[1]];
+			}
+			return null;
+		}
+
+		// YouTube → P1651: youtube.com/watch?v=, /embed/, plus youtu.be/<id>
+		if (preg_match('~^(?:www\.|m\.|music\.)?youtube\.com$~', $host)) {
+			parse_str($parts["query"] ?? "", $q);
+			if (isset($q["v"]) && is_string($q["v"]) && preg_match('~^[A-Za-z0-9_-]{6,}$~', $q["v"])) {
+				return [1651, $q["v"]];
+			}
+			if (preg_match('~^embed/([A-Za-z0-9_-]{6,})~', $path, $m)) {
+				return [1651, $m[1]];
+			}
+			return null;
+		}
+		if ($host === "youtu.be" || $host === "www.youtu.be") {
+			if (preg_match('~^([A-Za-z0-9_-]{6,})~', $path, $m)) {
+				return [1651, $m[1]];
+			}
+			return null;
+		}
+
+		// Vimeo → P4015 (numeric video ID)
+		if (preg_match('~^(?:www\.|player\.)?vimeo\.com$~', $host)) {
+			if (preg_match('~^(?:video/)?(\d+)~', $path, $m)) {
+				return [4015, $m[1]];
+			}
+			return null;
+		}
+
+		// Dailymotion → P11731
+		if (preg_match('~^(?:www\.)?dailymotion\.com$~', $host)) {
+			if (preg_match('~^video/([^/?#]+)~', $path, $m)) {
+				return [11731, $m[1]];
+			}
+			return null;
+		}
+
+		// Wikimedia Commons file pages → P10. Accept the common localised
+		// File-namespace prefixes since they all resolve to the same file.
+		if ($host === "commons.wikimedia.org" || $host === "commons.m.wikimedia.org") {
+			if (preg_match('~^wiki/(?:File|Datei|Fichier|Archivo|Plik|Bild):(.+)$~', $path, $m)) {
+				return [10, urldecode($m[1])];
+			}
+			return null;
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/unit/WikiStreamTest.php
+++ b/tests/unit/WikiStreamTest.php
@@ -1133,6 +1133,104 @@ final class WikiStreamTest extends TestCase
     }
 
     // ------------------------------------------------------------------
+    // B5: the P11484 "do not use for WikiFlix" qualifier (value
+    // Q124428688) must suppress file ingestion for ANY property in
+    // $config->file_props — not just P10 / P724. Regression test
+    // protects the universal opt-out behaviour at add_item_details.
+    // ------------------------------------------------------------------
+
+    /**
+     * Build a Wikidata claim object with a string mainsnak value and an
+     * optional P11484 opt-out qualifier.
+     */
+    private function makeFileClaim(string $key, bool $optOut = false): object
+    {
+        $claim = new \stdClass();
+        $claim->mainsnak = new \stdClass();
+        $claim->mainsnak->datavalue = new \stdClass();
+        $claim->mainsnak->datavalue->value = $key;
+        $claim->mainsnak->datavalue->type = 'string';
+        if ($optOut) {
+            $claim->qualifiers = new \stdClass();
+            $qual = new \stdClass();
+            $qual->datavalue = new \stdClass();
+            $qual->datavalue->value = (object) ['id' => 'Q124428688'];
+            $claim->qualifiers->P11484 = [$qual];
+        }
+        return $claim;
+    }
+
+    /**
+     * `$ws` matches the file-wide convention for the WikiStream-under-test
+     * variable; suppress PHPMD's ShortVariable rule for this method only.
+     *
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    public function test_p11484_opt_out_applies_to_all_file_props(): void
+    {
+        [$ws] = $this->makeWikiStream();
+
+        // One claim per file property; mix opted-out and clean.
+        $claims = [
+            10    => [
+                $this->makeFileClaim('Clean-Commons.webm'),
+                $this->makeFileClaim('OptedOut-Commons.webm', optOut: true),
+            ],
+            724   => [$this->makeFileClaim('clean-ia-id')],
+            1651  => [$this->makeFileClaim('optedout-yt-id', optOut: true)],
+            4015  => [$this->makeFileClaim('clean-vimeo-id')],
+            11731 => [$this->makeFileClaim('optedout-dm-id', optOut: true)],
+        ];
+
+        // Only getClaims is overridden; the bootstrap stub's defaults
+        // (empty label, empty sitelinks, empty getFirstString/getTarget)
+        // are sufficient for the opt-out code path we're exercising.
+        $item = new class($claims) extends \WikidataItem {
+            private array $claimsByProp;
+            public function __construct(array $claimsByProp)
+            {
+                parent::__construct((object) ['id' => 'Q42']);
+                $this->claimsByProp = $claimsByProp;
+            }
+            public function getClaims(string|int $prop): array
+            {
+                $key = (int) preg_replace('/\D/', '', (string) $prop);
+                return $this->claimsByProp[$key] ?? [];
+            }
+        };
+
+        $wil = new \WikidataItemList();
+        $wil->setItem(42, $item);
+
+        $qs = [];
+        $sections = [];
+        $entry_files = [];
+        $items_for_labels = []; // array form so add_item_details defers labels.
+        $item_rows = [];
+
+        // add_item_details is protected and takes references. bindTo() (the
+        // instance form of Closure::bind) lets the closure see protected
+        // methods while keeping by-reference args working — reflection's
+        // invokeArgs cannot pass references through.
+        $invoke = function ($wil, $q, &$qs, &$sections, &$entry_files, &$items_for_labels, &$item_rows) {
+            $this->add_item_details($wil, $q, $qs, $sections, $entry_files, $items_for_labels, $item_rows);
+        };
+        $invoke = $invoke->bindTo($ws, \WikiStream::class);
+        $invoke($wil, 42, $qs, $sections, $entry_files, $items_for_labels, $item_rows);
+
+        // Clean files for every property are kept; opted-out keys are dropped.
+        $joined = implode("\n", $entry_files);
+        $this->assertStringContainsString('Clean-Commons.webm', $joined, 'Clean P10 file must be kept.');
+        $this->assertStringContainsString('clean-ia-id', $joined, 'Clean P724 file must be kept.');
+        $this->assertStringContainsString('clean-vimeo-id', $joined, 'Clean P4015 file must be kept.');
+
+        $this->assertStringNotContainsString('OptedOut-Commons.webm', $joined, 'P10 opt-out must filter the file.');
+        $this->assertStringNotContainsString('optedout-yt-id', $joined, 'P1651 opt-out must filter the file.');
+        $this->assertStringNotContainsString('optedout-dm-id', $joined, 'P11731 opt-out must filter the file.');
+
+        $this->assertCount(3, $entry_files, 'Exactly 3 clean files (one per non-opted-out claim) must be ingested.');
+    }
+
     // A4: WikiStream::parseP953Url() maps a wdt:P953 URL to a (file-prop,
     // key) pair so the bot can add the corresponding native file-host
     // property (P10/P724/P1651/P4015/P11731). Pure function, table-driven

--- a/tests/unit/WikiStreamTest.php
+++ b/tests/unit/WikiStreamTest.php
@@ -1131,4 +1131,310 @@ final class WikiStreamTest extends TestCase
 
         $this->assertCount(0, $ws->capturedCommands);
     }
+
+    // ------------------------------------------------------------------
+    // A4: WikiStream::parseP953Url() maps a wdt:P953 URL to a (file-prop,
+    // key) pair so the bot can add the corresponding native file-host
+    // property (P10/P724/P1651/P4015/P11731). Pure function, table-driven
+    // tests.
+    // ------------------------------------------------------------------
+
+    public static function provideP953UrlCases(): array
+    {
+        return [
+            ['https://archive.org/details/CharlieChaplin_TheGoldRush',          [724,  'CharlieChaplin_TheGoldRush']],
+            ['http://archive.org/details/some-id',                              [724,  'some-id']],
+            ['https://www.archive.org/details/another',                         [724,  'another']],
+            ['https://archive.org/embed/abc',                                   null],
+            ['https://www.youtube.com/watch?v=dQw4w9WgXcQ',                     [1651, 'dQw4w9WgXcQ']],
+            ['https://youtube.com/watch?v=abc123XYZ',                           [1651, 'abc123XYZ']],
+            ['https://m.youtube.com/watch?v=zzzz_-9999',                        [1651, 'zzzz_-9999']],
+            ['https://www.youtube.com/embed/dQw4w9WgXcQ',                       [1651, 'dQw4w9WgXcQ']],
+            ['https://youtu.be/dQw4w9WgXcQ',                                    [1651, 'dQw4w9WgXcQ']],
+            ['https://vimeo.com/12345678',                                      [4015, '12345678']],
+            ['https://player.vimeo.com/video/12345678',                         [4015, '12345678']],
+            ['https://vimeo.com/notnumeric',                                    null],
+            ['https://www.dailymotion.com/video/x7tgad0',                       [11731, 'x7tgad0']],
+            ['https://dailymotion.com/video/abcd',                              [11731, 'abcd']],
+            ['https://commons.wikimedia.org/wiki/File:Big_Buck_Bunny.webm',     [10,   'Big_Buck_Bunny.webm']],
+            ['https://commons.m.wikimedia.org/wiki/File:Sintel.webm',           [10,   'Sintel.webm']],
+            ['https://commons.wikimedia.org/wiki/File:Some%20Title.webm',       [10,   'Some Title.webm']],
+            ['',                                                                null],
+            ['not a url at all',                                                null],
+            ['https://example.com/random',                                      null],
+            ['https://twitter.com/some/post',                                   null],
+            ['https://www.youtube.com/channel/UCabcd',                          null],
+        ];
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.StaticAccess)
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideP953UrlCases')]
+    public function test_parseP953Url(string $url, ?array $expected): void
+    {
+        $this->assertSame($expected, \WikiStream::parseP953Url($url));
+    }
+
+    // ------------------------------------------------------------------
+    // A4: import_p953_urls() promotes wdt:P953 URLs into native host
+    // properties via QuickStatements; honours the P11484 opt-out
+    // qualifier and a per-run cap.
+    // ------------------------------------------------------------------
+
+    private function makeP953Claim(string $url, bool $optOut = false): object
+    {
+        $claim = new \stdClass();
+        $claim->mainsnak = new \stdClass();
+        $claim->mainsnak->datavalue = new \stdClass();
+        $claim->mainsnak->datavalue->value = $url;
+        $claim->mainsnak->datavalue->type = 'string';
+        if ($optOut) {
+            $claim->qualifiers = new \stdClass();
+            $qual = new \stdClass();
+            $qual->datavalue = new \stdClass();
+            $qual->datavalue->value = (object) ['id' => 'Q124428688'];
+            $claim->qualifiers->P11484 = [$qual];
+        }
+        return $claim;
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    private function makeRecordingWikiStream(\WikidataItemList $wil, \ToolforgeCommon $tfc): object
+    {
+        $config = new \WikiStreamConfigWikiFlix();
+        return new class($config, $tfc, null, $wil) extends \WikiStream {
+            public array $capturedCommands = [];
+            private \WikidataItemList $injectedWil;
+            public function __construct($config, $tfc, $http, \WikidataItemList $wil)
+            {
+                parent::__construct($config, $tfc, $http);
+                $this->injectedWil = $wil;
+            }
+            protected function loadWikidataItemList(array $qs): \WikidataItemList
+            {
+                unset($qs);
+                return $this->injectedWil;
+            }
+            protected function pushQuickStatements(array $commands): void
+            {
+                $this->capturedCommands = $commands;
+            }
+        };
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    public function test_import_p953_urls_emits_commands_for_known_hosts(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+        $tfc->method('getSPARQL_TSV')->willReturn([
+            ['q' => 'http://www.wikidata.org/entity/Q42'],
+        ]);
+        $tfc->method('parseItemFromURL')->willReturnCallback(
+            fn(string $url) => preg_match('~Q\d+$~', $url, $m) ? $m[0] : ''
+        );
+
+        $claims = [
+            $this->makeP953Claim('https://archive.org/details/foo'),
+            $this->makeP953Claim('https://www.youtube.com/watch?v=AAAAAAAAAAA'),
+            $this->makeP953Claim('https://example.com/unsupported'),
+            $this->makeP953Claim('https://vimeo.com/123', optOut: true),
+        ];
+        $item = new class($claims) extends \WikidataItem {
+            private array $p953;
+            public function __construct(array $p953)
+            {
+                parent::__construct((object) ['id' => 'Q42']);
+                $this->p953 = $p953;
+            }
+            public function getClaims(string|int $prop): array
+            {
+                $key = (int) preg_replace('/\D/', '', (string) $prop);
+                return $key === 953 ? $this->p953 : [];
+            }
+        };
+
+        $wil = new \WikidataItemList();
+        $wil->setItem(42, $item);
+
+        $ws = $this->makeRecordingWikiStream($wil, $tfc);
+        $ws->import_p953_urls();
+
+        $this->assertCount(2, $ws->capturedCommands);
+
+        $joined = implode("\n", $ws->capturedCommands);
+        $this->assertStringContainsString("Q42\tP724\t\"foo\"", $joined);
+        $this->assertStringContainsString("Q42\tP1651\t\"AAAAAAAAAAA\"", $joined);
+        $this->assertStringNotContainsString('123', $joined);
+    }
+
+    // ------------------------------------------------------------------
+    // A5: import_ia_curated_films() INSERTs items whose IA collection is
+    // in the curated whitelist.
+    // ------------------------------------------------------------------
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    public function test_import_ia_curated_films_inserts_only_whitelisted_collections(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+        $tfc->method('getSPARQL_TSV')->willReturn([
+            ['q' => 'http://www.wikidata.org/entity/Q101', 'ia' => 'feature-film-1'],
+            ['q' => 'http://www.wikidata.org/entity/Q102', 'ia' => 'random-clip'],
+            ['q' => 'http://www.wikidata.org/entity/Q103', 'ia' => 'silent-film-1'],
+            ['q' => 'http://www.wikidata.org/entity/Q104', 'ia' => 'dark-item'],
+        ]);
+        $tfc->method('parseItemFromURL')->willReturnCallback(
+            fn(string $url) => preg_match('~Q\d+$~', $url, $m) ? $m[0] : ''
+        );
+
+        $insertSqls = [];
+        $tfc->method('getSQL')->willReturnCallback(function ($db, string $sql) use (&$insertSqls) {
+            if (stripos($sql, 'INSERT') === 0) {
+                $insertSqls[] = $sql;
+            }
+            return $this->emptyResult();
+        });
+
+        $http = $this->createMock(\HttpClientInterface::class);
+        $http->method('getJsonBatch')->willReturnCallback(function (array $urlsByKey) {
+            $byQ = [];
+            foreach ($urlsByKey as $q => $url) {
+                $j = new \stdClass();
+                $j->metadata = new \stdClass();
+                if (str_contains($url, 'feature-film-1')) {
+                    $j->metadata->collection = ['feature_films_unsorted', 'feature_films'];
+                } elseif (str_contains($url, 'silent-film-1')) {
+                    $j->metadata->collection = ['silent_films'];
+                } elseif (str_contains($url, 'random-clip')) {
+                    $j->metadata->collection = ['some_random_collection'];
+                } elseif (str_contains($url, 'dark-item')) {
+                    $j->is_dark = true;
+                }
+                $byQ[$q] = $j;
+            }
+            return $byQ;
+        });
+
+        $config = new \WikiStreamConfigWikiFlix();
+        $ws = new \WikiStream($config, $tfc, $http);
+        $ws->import_ia_curated_films();
+
+        $joined = implode("\n", $insertSqls);
+        $this->assertStringContainsString('101', $joined);
+        $this->assertStringContainsString('103', $joined);
+        $this->assertStringNotContainsString('102', $joined);
+        $this->assertStringNotContainsString('104', $joined);
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    public function test_import_ia_curated_films_no_candidates_skips_http(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+        $tfc->method('getSPARQL_TSV')->willReturn([]);
+
+        $http = $this->createMock(\HttpClientInterface::class);
+        $http->expects($this->never())->method('getJsonBatch');
+        $http->expects($this->never())->method('getJson');
+
+        $config = new \WikiStreamConfigWikiFlix();
+        $ws = new \WikiStream($config, $tfc, $http);
+        $ws->import_ia_curated_films();
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    public function test_import_ia_curated_films_caps_per_run(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+
+        $rows = [];
+        for ($q = 1; $q <= 200; $q++) {
+            $rows[] = ['q' => "http://www.wikidata.org/entity/Q{$q}", 'ia' => "ia-id-{$q}"];
+        }
+        $tfc->method('getSPARQL_TSV')->willReturn($rows);
+        $tfc->method('parseItemFromURL')->willReturnCallback(
+            fn(string $url) => preg_match('~Q\d+$~', $url, $m) ? $m[0] : ''
+        );
+        $tfc->method('getSQL')->willReturn($this->emptyResult());
+
+        $http = $this->createMock(\HttpClientInterface::class);
+        $batchCalls = 0;
+        $http->method('getJsonBatch')->willReturnCallback(function (array $urlsByKey) use (&$batchCalls) {
+            $batchCalls++;
+            $byQ = [];
+            foreach (array_keys($urlsByKey) as $q) {
+                $j = new \stdClass();
+                $j->metadata = new \stdClass();
+                $j->metadata->collection = ['feature_films'];
+                $byQ[$q] = $j;
+            }
+            return $byQ;
+        });
+
+        $config = new \WikiStreamConfigWikiFlix();
+        $ws = new \WikiStream($config, $tfc, $http);
+        $ws->import_ia_curated_films();
+
+        $this->assertGreaterThan(0, $batchCalls);
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    public function test_import_p953_urls_caps_commands_per_run(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+
+        $rows = [];
+        for ($q = 1; $q <= 150; $q++) {
+            $rows[] = ['q' => "http://www.wikidata.org/entity/Q{$q}"];
+        }
+        $tfc->method('getSPARQL_TSV')->willReturn($rows);
+        $tfc->method('parseItemFromURL')->willReturnCallback(
+            fn(string $url) => preg_match('~Q\d+$~', $url, $m) ? $m[0] : ''
+        );
+
+        $wil = new \WikidataItemList();
+        for ($q = 1; $q <= 150; $q++) {
+            $claim = $this->makeP953Claim("https://archive.org/details/id{$q}");
+            $item = new class([$claim], $q) extends \WikidataItem {
+                private array $p953;
+                public function __construct(array $p953, int $q)
+                {
+                    parent::__construct((object) ['id' => "Q{$q}"]);
+                    $this->p953 = $p953;
+                }
+                public function getClaims(string|int $prop): array
+                {
+                    $key = (int) preg_replace('/\D/', '', (string) $prop);
+                    return $key === 953 ? $this->p953 : [];
+                }
+            };
+            $wil->setItem($q, $item);
+        }
+
+        $ws = $this->makeRecordingWikiStream($wil, $tfc);
+        $ws->import_p953_urls();
+
+        $this->assertSame(\WikiStream::P953_COMMANDS_PER_RUN, count($ws->capturedCommands));
+    }
 }


### PR DESCRIPTION
## Summary

Second of three PRs from the WikiFlix \"find more eligible movies\" audit. Two commits, both adding new ingestion paths under existing pipeline conventions.

- **A4** — \`import_p953_urls()\`. P953 (\"full work available at URL\") is widely populated on Wikidata; the pipeline only ingests native host properties (P10/P724/P1651/P4015/P11731). This bot finds films with a P953 URL but no native host property, parses the URL via the pure helper \`parseP953Url()\` to identify a known host + ID (archive.org, youtube.com, youtu.be, vimeo.com, dailymotion.com, commons.wikimedia.org), and queues a QuickStatements add-statement to promote it. Bot activity is capped at \`P953_COMMANDS_PER_RUN = 100\` edits per invocation. Live SPARQL: ~7,280 candidate films.
- **A5** — \`import_ia_curated_films()\`. Query #3's 60–150 % duration filter + year-≤-1928 cut-off is deliberately conservative; films in IA's curated collections (\`feature_films\`, \`silent_films\`, \`prelinger\`) don't need the duration check because IA already vetted them. This method finds matching candidates, fetches \`archive.org/metadata/<id>\` (capped at \`IA_CURATED_CANDIDATES_PER_RUN = 200\` per run), and INSERTs into \`item\` those whose collection list intersects the whitelist. Live SPARQL: ~1,547 candidate films before the curation check.

## Deferred — A3

A3 (P10 duration-match without the \`full video\` qualifier) is deferred. The flavour-A SPARQL-only approach returns **0 films** on live Wikidata — editors don't put \`pq:P2047\` duration qualifiers on P10 statements, so there's nothing for SPARQL to match. The flavour-B alternative (SPARQL discovery + Commons API duration check + cleanup pass) needs a schema marker to distinguish A3-sourced items from existing ones (otherwise the cleanup could violate the \"don't exclude currently-included films\" constraint). That's its own design discussion and was not safe to bundle here. Recommend a follow-up issue.

## Constraint compliance

- **Don't exclude currently-included films.** A4 is additive (it adds new statements to Wikidata, downstream pipeline picks them up). A5 is additive (it ingests new q's; query #3 keeps working unchanged for everything it already catches). Neither touches existing data. ✓
- **No CC-*-ND ingestion.** Same as the existing pipeline — A4/A5 don't introduce new license paths. ✓

## Infrastructure changes (reusable)

Two protected helpers extracted on \`WikiStream\`:
- \`loadWikidataItemList(\$qs)\` — factory tests can override.
- \`pushQuickStatements(\$commands)\` — no-ops when the local QuickStatements library isn't installed (dev/test). Mirrors the inline pattern in \`annotate_ia_movies\`; could be refactored to use it in a follow-up.

## Test plan

- [x] \`vendor/bin/phpunit\` — 153 tests, 265 assertions, all green
- [x] 22 \`parseP953Url\` data-provider cases (archive.org, youtube.com, youtu.be, vimeo.com, dailymotion.com, commons.wikimedia.org incl. URL-decoding + localised File: prefixes + negative cases)
- [x] \`import_p953_urls\` — known/unknown hosts, opt-out qualifier, per-run cap
- [x] \`import_ia_curated_films\` — collection whitelist, dark-item skip, no-candidates fast-path, cap
- [x] Live SPARQL validation for both new queries
- [ ] After merge: one cron run of \`scripts/update.php\` to confirm QS edits land and no new items error out