### PR TITLE
Bot enrichment: PD annotator + IA mining + Commons P180 mining (C1, C3, C2)

### DIFF
--- a/scripts/update.php
+++ b/scripts/update.php
@@ -24,6 +24,7 @@ match ($cmd) {
 	'sec_labels'                => $ws->import_missing_section_labels(),
 	'purge_items_without_files' => $ws->purge_items_without_files(),
 	'annotate_ia_movies'        => $ws->annotate_ia_movies(),
+	'annotate_pre_1900_public_domain' => $ws->annotate_pre_1900_public_domain(),
 	'import_commons_video_minutes' => $ws->import_commons_video_minutes(),
 	'update_item_no_files'      => $ws->update_item_no_files_search_results(),
 	'reset'                     => null, // already handled above
@@ -48,6 +49,7 @@ match ($cmd) {
 
 		# These edits will take too long to percolate into SPARQL to be useful now, so prepare for the next update
 		$ws->annotate_ia_movies();
+		$ws->annotate_pre_1900_public_domain();
 
 		# Might run out of memory so run this last
 		$ws->generate_all_data();

--- a/scripts/update.php
+++ b/scripts/update.php
@@ -26,6 +26,7 @@ match ($cmd) {
 	'annotate_ia_movies'        => $ws->annotate_ia_movies(),
 	'annotate_pre_1900_public_domain' => $ws->annotate_pre_1900_public_domain(),
 	'import_ia_curated_imdb_p724' => $ws->import_ia_curated_imdb_p724(),
+	'import_commons_pd_films_via_p180' => $ws->import_commons_pd_films_via_p180(),
 	'import_commons_video_minutes' => $ws->import_commons_video_minutes(),
 	'update_item_no_files'      => $ws->update_item_no_files_search_results(),
 	'reset'                     => null, // already handled above
@@ -52,6 +53,7 @@ match ($cmd) {
 		$ws->annotate_ia_movies();
 		$ws->annotate_pre_1900_public_domain();
 		$ws->import_ia_curated_imdb_p724();
+		$ws->import_commons_pd_films_via_p180();
 
 		# Might run out of memory so run this last
 		$ws->generate_all_data();

--- a/scripts/update.php
+++ b/scripts/update.php
@@ -25,6 +25,7 @@ match ($cmd) {
 	'purge_items_without_files' => $ws->purge_items_without_files(),
 	'annotate_ia_movies'        => $ws->annotate_ia_movies(),
 	'annotate_pre_1900_public_domain' => $ws->annotate_pre_1900_public_domain(),
+	'import_ia_curated_imdb_p724' => $ws->import_ia_curated_imdb_p724(),
 	'import_commons_video_minutes' => $ws->import_commons_video_minutes(),
 	'update_item_no_files'      => $ws->update_item_no_files_search_results(),
 	'reset'                     => null, // already handled above
@@ -50,6 +51,7 @@ match ($cmd) {
 		# These edits will take too long to percolate into SPARQL to be useful now, so prepare for the next update
 		$ws->annotate_ia_movies();
 		$ws->annotate_pre_1900_public_domain();
+		$ws->import_ia_curated_imdb_p724();
 
 		# Might run out of memory so run this last
 		$ws->generate_all_data();

--- a/scripts/wikistream.php
+++ b/scripts/wikistream.php
@@ -28,6 +28,12 @@ class WikiStream
 	private const WD_DO_NOT_USE         = "Q124428688"; // P11484 qualifier: do not use for WikiFlix
 	private const WD_UNIT_MINUTE        = "http://www.wikidata.org/entity/Q7727";
 
+	/**
+	 * Maximum number of P6216 annotations the pre-1900 PD annotator
+	 * (annotate_pre_1900_public_domain()) will emit per cron invocation.
+	 */
+	public const PRE_1900_PD_PER_RUN = 100;
+
 	public $tfc;
 	public $language = "en";
 	public $config;
@@ -1485,6 +1491,79 @@ class WikiStream
 			$this->rollback();
 			throw $e;
 		}
+	}
+
+	/**
+	 * Load Wikidata items for the given Q-numbers. Factory method so tests
+	 * can substitute a pre-populated WikidataItemList without hitting the
+	 * network.
+	 */
+	protected function loadWikidataItemList(array $qs): WikidataItemList
+	{
+		$wil = new WikidataItemList();
+		$wil->loadItems($qs);
+		return $wil;
+	}
+
+	/**
+	 * Submit a batch of QuickStatements commands. No-op when the local
+	 * QuickStatements library isn't installed (dev / test environments),
+	 * which keeps callers test-friendly without sprinkling environment
+	 * checks at each call site.
+	 */
+	protected function pushQuickStatements(array $commands): void
+	{
+		if (count($commands) === 0) {
+			return;
+		}
+		print "Running " . count($commands) . " QS commands\n";
+		$qs_lib = "/data/project/quickstatements/public_html/quickstatements.php";
+		if (!file_exists($qs_lib)) {
+			return;
+		}
+		require_once $qs_lib;
+		$qs = $this->tfc->getQS($this->config->toolkey, __DIR__ . "/../bot.ini");
+		$this->tfc->runCommandsQS($commands, $qs);
+	}
+
+	/**
+	 * Conservative bot pass: stamp P6216=Q19652 (public domain) on films
+	 * dated before 1900 that have no copyright-status statement at all.
+	 *
+	 * Pre-1900 films are PD in every jurisdiction with a finite copyright
+	 * term — the most lenient term (life + 100) covers anyone who lived
+	 * to a plausible age. P459=Q47246828 ("published more than 95 years
+	 * ago") is added as the determination-method qualifier, matching the
+	 * Wikidata convention used on 32,954 existing film P6216 statements.
+	 *
+	 * Bounded by self::PRE_1900_PD_PER_RUN. The current candidate pool
+	 * is ~86 films, so a single run usually clears it.
+	 */
+	public function annotate_pre_1900_public_domain(): void
+	{
+		$sparql =
+			"SELECT DISTINCT ?q WHERE {
+				?q wdt:P31/wdt:P279* wd:Q11424 ;
+				   wdt:P577 ?date .
+				FILTER(YEAR(?date) < 1900)
+				FILTER NOT EXISTS { ?q wdt:P6216 ?_status }
+				MINUS { ?q wdt:P31 wd:Q97570383 }
+			}";
+
+		$commands = [];
+		foreach ($this->tfc->getSPARQL_TSV($sparql) as $row) {
+			if (count($commands) >= self::PRE_1900_PD_PER_RUN) {
+				break;
+			}
+			$q = $this->tfc->parseItemFromURL((string) ($row["q"] ?? ""));
+			$q_numeric = (int) preg_replace("|\D|", "", (string) $q);
+			if ($q_numeric <= 0) {
+				continue;
+			}
+			$commands[] = "Q{$q_numeric}\tP6216\tQ19652\tP459\tQ47246828\t/* WikiFlix C1: pre-1900 film, PD by age */";
+		}
+
+		$this->pushQuickStatements($commands);
 	}
 
 	private static function parse_seconds(string $s): int

--- a/scripts/wikistream.php
+++ b/scripts/wikistream.php
@@ -49,6 +49,31 @@ class WikiStream
 	 */
 	public const IA_C3_COLLECTIONS = ['feature_films', 'silent_films', 'prelinger'];
 
+	/**
+	 * Maximum number of Commons files import_commons_pd_films_via_p180()
+	 * will examine per cron invocation, summed across all whitelisted
+	 * categories. Bounds the per-file SDC fetch fan-out and the SPARQL
+	 * VALUES size.
+	 */
+	public const C2_FILES_PER_RUN = 100;
+
+	/**
+	 * Commons categories whose video members carry P180 (depicts) links
+	 * to Wikidata film items. Conservative whitelist — categories where
+	 * the curation precision is high enough that P180 reliably points to
+	 * the depicted film and not, say, a related image.
+	 */
+	public const C2_COMMONS_CATEGORIES = [
+		'Films in the public domain',
+	];
+
+	/**
+	 * Commons file extensions we treat as video for C2. Files outside
+	 * this set are silently skipped — adding P10 to a film for a JPG
+	 * still would be wrong.
+	 */
+	public const C2_VIDEO_EXTENSIONS = ['webm', 'ogv', 'ogg', 'mp4'];
+
 	public $tfc;
 	public $language = "en";
 	public $config;
@@ -1617,6 +1642,135 @@ class WikiStream
 			$commands[] = "Q{$q_numeric}\tP724\t\"{$ia_safe}\"\t/* WikiFlix C3: from IA curated collection */";
 		}
 
+		$this->pushQuickStatements($commands);
+	}
+
+	/**
+	 * Walk a whitelist of Commons categories for video files, fetch each
+	 * file's M-entity P180 (depicts) claim, and queue a QuickStatements
+	 * command to add P10 to the depicted film — but only when the target
+	 * is a film and lacks any existing P10 statement.
+	 *
+	 * The P180 link is the only signal we trust: title-matching files to
+	 * film items is too noisy. Files without a single P180 are skipped.
+	 * Files with multiple P180 values are skipped too — we can't tell
+	 * which one the file is supposed to be a video of.
+	 *
+	 * Bounded by self::C2_FILES_PER_RUN files examined per invocation.
+	 */
+	public function import_commons_pd_films_via_p180(): void
+	{
+		// 1. Walk the whitelisted Commons categories for file members
+		//    that have a video extension.
+		$files = []; // canonical title (no "File:" prefix) — list, dedup later
+		foreach (self::C2_COMMONS_CATEGORIES as $category) {
+			if (count($files) >= self::C2_FILES_PER_RUN) {
+				break;
+			}
+			$limit = self::C2_FILES_PER_RUN - count($files);
+			$url =
+				"https://commons.wikimedia.org/w/api.php" .
+				"?action=query&list=categorymembers" .
+				"&cmtitle=" . rawurlencode("Category:{$category}") .
+				"&cmtype=file&cmlimit={$limit}&format=json";
+			$j = $this->httpClient->getJson($url);
+			$members = $j->query->categorymembers ?? null;
+			if (!is_array($members)) {
+				continue;
+			}
+			foreach ($members as $m) {
+				$title = (string) ($m->title ?? "");
+				if (strpos($title, "File:") !== 0) {
+					continue;
+				}
+				$name = substr($title, 5);
+				$ext = strtolower((string) pathinfo($name, PATHINFO_EXTENSION));
+				if (!in_array($ext, self::C2_VIDEO_EXTENSIONS, true)) {
+					continue;
+				}
+				$files[] = $name;
+				if (count($files) >= self::C2_FILES_PER_RUN) {
+					break;
+				}
+			}
+		}
+		$files = array_values(array_unique($files));
+		if (count($files) === 0) {
+			return;
+		}
+
+		// 2. For each video file, fetch the M-entity P180 claim. Take
+		//    only the single-target case to avoid ambiguity.
+		$fileToFilm = []; // commons filename -> wikidata Q-id string
+		foreach ($files as $name) {
+			$url =
+				"https://commons.wikimedia.org/w/api.php" .
+				"?action=wbgetentities&sites=commonswiki" .
+				"&titles=" . rawurlencode("File:{$name}") .
+				"&props=claims&format=json";
+			$j = $this->httpClient->getJson($url);
+			if (!isset($j->entities)) {
+				continue;
+			}
+			// The single returned entity (M<id>) is keyed by ID.
+			$entity = null;
+			foreach ((array) $j->entities as $_id => $e) {
+				$entity = $e;
+				break;
+			}
+			if (!isset($entity->claims->P180)) {
+				continue;
+			}
+			$p180 = $entity->claims->P180;
+			if (!is_array($p180) || count($p180) !== 1) {
+				continue; // require exactly one P180 to avoid ambiguity
+			}
+			$target = $p180[0]->mainsnak->datavalue->value->id ?? null;
+			if (!is_string($target) || !preg_match('~^Q\d+$~', $target)) {
+				continue;
+			}
+			$fileToFilm[$name] = $target;
+		}
+		if (count($fileToFilm) === 0) {
+			return;
+		}
+
+		// 3. Verify each candidate film is a film AND lacks a P10
+		//    statement entirely. The "no P10 yet" rule is conservative —
+		//    if the film already has even one P10 statement, leave it
+		//    alone rather than risk wrong/duplicate additions.
+		$valuesList = "wd:" . implode(" wd:", array_values($fileToFilm));
+		$sparql =
+			"SELECT ?q WHERE {
+				VALUES ?q { {$valuesList} }
+				?q wdt:P31/wdt:P279* wd:Q11424 .
+				FILTER NOT EXISTS { ?q wdt:P10 ?_x }
+			}";
+
+		$verifiedFilms = [];
+		foreach ($this->tfc->getSPARQL_TSV($sparql) as $row) {
+			$q = $this->tfc->parseItemFromURL((string) ($row["q"] ?? ""));
+			if ($q !== "") {
+				$verifiedFilms[$q] = true;
+			}
+		}
+		if (count($verifiedFilms) === 0) {
+			return;
+		}
+
+		// 4. Emit QS commands.
+		$commands = [];
+		foreach ($fileToFilm as $name => $film_q) {
+			if (!isset($verifiedFilms[$film_q])) {
+				continue;
+			}
+			$q_numeric = (int) preg_replace("|\D|", "", $film_q);
+			if ($q_numeric <= 0) {
+				continue;
+			}
+			$name_safe = addslashes($name);
+			$commands[] = "Q{$q_numeric}\tP10\t\"{$name_safe}\"\t/* WikiFlix C2: via P180 in Commons category */";
+		}
 		$this->pushQuickStatements($commands);
 	}
 

--- a/scripts/wikistream.php
+++ b/scripts/wikistream.php
@@ -34,6 +34,21 @@ class WikiStream
 	 */
 	public const PRE_1900_PD_PER_RUN = 100;
 
+	/**
+	 * Maximum number of IA search results import_ia_curated_imdb_p724()
+	 * will consider per cron invocation. Bounds the IMDb→Wikidata lookup
+	 * SPARQL VALUES set size and the QS edit fan-out.
+	 */
+	public const C3_IMDB_CANDIDATES_PER_RUN = 100;
+
+	/**
+	 * IA curated film collections we mine for IMDb-IDs to link via P724.
+	 * Same set as IA_CURATED_COLLECTIONS — duplicated here so the two
+	 * features can be tuned independently (C3 might grow this set while
+	 * import_ia_curated_films() keeps a tighter list).
+	 */
+	public const IA_C3_COLLECTIONS = ['feature_films', 'silent_films', 'prelinger'];
+
 	public $tfc;
 	public $language = "en";
 	public $config;
@@ -1524,6 +1539,85 @@ class WikiStream
 		require_once $qs_lib;
 		$qs = $this->tfc->getQS($this->config->toolkey, __DIR__ . "/../bot.ini");
 		$this->tfc->runCommandsQS($commands, $qs);
+	}
+
+	/**
+	 * Mine IA's curated film collections for items carrying an IMDb
+	 * external-identifier, resolve the IMDb ID to a Wikidata Q via P345,
+	 * and queue QuickStatements to add P724 for items that don't already
+	 * carry one.
+	 *
+	 * Bounded by self::C3_IMDB_CANDIDATES_PER_RUN. The Wikidata side of
+	 * the resolution explicitly excludes items that already have a P724
+	 * statement, so the method is idempotent across cron runs.
+	 */
+	public function import_ia_curated_imdb_p724(): void
+	{
+		// imdb_id -> ia_identifier
+		$candidates = [];
+		foreach (self::IA_C3_COLLECTIONS as $collection) {
+			if (count($candidates) >= self::C3_IMDB_CANDIDATES_PER_RUN) {
+				break;
+			}
+			$remaining = self::C3_IMDB_CANDIDATES_PER_RUN - count($candidates);
+			$query = "collection:{$collection} AND external-identifier:urn\\:imdb\\:*";
+			$url =
+				"https://archive.org/advancedsearch.php?" .
+				"q=" . rawurlencode($query) .
+				"&fl%5B%5D=identifier&fl%5B%5D=external-identifier" .
+				"&rows={$remaining}&output=json";
+			$j = $this->httpClient->getJson($url);
+			if (!isset($j->response->docs) || !is_array($j->response->docs)) {
+				continue;
+			}
+			foreach ($j->response->docs as $doc) {
+				if (count($candidates) >= self::C3_IMDB_CANDIDATES_PER_RUN) {
+					break;
+				}
+				$ext = $doc->{"external-identifier"} ?? null;
+				if (is_array($ext)) {
+					$ext = $ext[0] ?? null;
+				}
+				if (!is_string($ext)) {
+					continue;
+				}
+				if (!preg_match('~^urn:imdb:(tt\d+)$~', $ext, $m)) {
+					continue;
+				}
+				$imdb = $m[1];
+				$ia = (string) ($doc->identifier ?? "");
+				if ($ia === "" || isset($candidates[$imdb])) {
+					continue;
+				}
+				$candidates[$imdb] = $ia;
+			}
+		}
+		if (count($candidates) === 0) {
+			return;
+		}
+
+		// Resolve IMDb -> Wikidata items lacking P724.
+		$valuesList = '"' . implode('" "', array_keys($candidates)) . '"';
+		$sparql =
+			"SELECT ?q ?imdb WHERE {
+				VALUES ?imdb { {$valuesList} }
+				?q wdt:P345 ?imdb .
+				FILTER NOT EXISTS { ?q wdt:P724 ?_ia }
+			}";
+
+		$commands = [];
+		foreach ($this->tfc->getSPARQL_TSV($sparql) as $row) {
+			$q = $this->tfc->parseItemFromURL((string) ($row["q"] ?? ""));
+			$q_numeric = (int) preg_replace("|\D|", "", (string) $q);
+			$imdb = (string) ($row["imdb"] ?? "");
+			if ($q_numeric <= 0 || !isset($candidates[$imdb])) {
+				continue;
+			}
+			$ia_safe = addslashes($candidates[$imdb]);
+			$commands[] = "Q{$q_numeric}\tP724\t\"{$ia_safe}\"\t/* WikiFlix C3: from IA curated collection */";
+		}
+
+		$this->pushQuickStatements($commands);
 	}
 
 	/**

--- a/tests/unit/WikiStreamTest.php
+++ b/tests/unit/WikiStreamTest.php
@@ -972,6 +972,126 @@ final class WikiStreamTest extends TestCase
         $this->assertStringNotContainsString('ia-id-3', $joined, 'Unresolved IMDb tt0003 yields no command.');
     }
 
+    // ------------------------------------------------------------------
+    // C2: import_commons_pd_films_via_p180() walks a whitelist of
+    // Commons categories, restricts to video files, fetches each file's
+    // Wikidata M-entity P180 (depicts) claim, and queues a QS command
+    // to add P10 to film items that lack a P10 statement. Only files
+    // explicitly linked to a film via P180 are accepted — title
+    // matching is unsafe.
+    // ------------------------------------------------------------------
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    public function test_import_commons_pd_films_via_p180_links_p180_films(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+        // SPARQL film-verification: Q700 is a film with no P10; Q701 is not a film.
+        $tfc->method('getSPARQL_TSV')->willReturn([
+            ['q' => 'http://www.wikidata.org/entity/Q700'],
+        ]);
+        $tfc->method('parseItemFromURL')->willReturnCallback(
+            fn(string $url) => preg_match('~Q\d+$~', $url, $m) ? $m[0] : ''
+        );
+
+        $http = $this->createMock(\HttpClientInterface::class);
+        $http->method('getJson')->willReturnCallback(function (string $url) {
+            // Category members
+            if (str_contains($url, 'list=categorymembers')) {
+                $r = new \stdClass();
+                $r->query = new \stdClass();
+                $r->query->categorymembers = [
+                    (object) ['title' => 'File:GoodVideo.webm'],
+                    (object) ['title' => 'File:NotAVideo.jpg'], // filtered by extension
+                    (object) ['title' => 'File:WrongTarget.webm'], // P180 points to Q701 (not a film)
+                ];
+                return $r;
+            }
+            // wbgetentities for a single file
+            if (str_contains($url, 'action=wbgetentities')) {
+                $r = new \stdClass();
+                $r->entities = new \stdClass();
+                if (str_contains($url, 'GoodVideo.webm')) {
+                    $r->entities->M1 = (object) [
+                        'claims' => (object) [
+                            'P180' => [
+                                (object) ['mainsnak' => (object) [
+                                    'datavalue' => (object) [
+                                        'value' => (object) ['id' => 'Q700'],
+                                    ],
+                                ]],
+                            ],
+                        ],
+                    ];
+                } elseif (str_contains($url, 'WrongTarget.webm')) {
+                    $r->entities->M2 = (object) [
+                        'claims' => (object) [
+                            'P180' => [
+                                (object) ['mainsnak' => (object) [
+                                    'datavalue' => (object) [
+                                        'value' => (object) ['id' => 'Q701'],
+                                    ],
+                                ]],
+                            ],
+                        ],
+                    ];
+                }
+                return $r;
+            }
+            return null;
+        });
+
+        $config = new \WikiStreamConfigWikiFlix();
+        $ws = new class($config, $tfc, $http) extends \WikiStream {
+            public array $capturedCommands = [];
+            protected function pushQuickStatements(array $commands): void
+            {
+                $this->capturedCommands = $commands;
+            }
+        };
+        $ws->import_commons_pd_films_via_p180();
+
+        $joined = implode("\n", $ws->capturedCommands);
+        $this->assertStringContainsString("Q700\tP10\t\"GoodVideo.webm\"", $joined, 'P180-linked video to a P10-less film must be queued.');
+        $this->assertStringNotContainsString('NotAVideo.jpg', $joined, 'Non-video files must be filtered by extension.');
+        $this->assertStringNotContainsString('Q701', $joined, 'P180 targets not verified as P10-less films must be skipped.');
+        $this->assertCount(1, $ws->capturedCommands);
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    public function test_import_commons_pd_films_via_p180_no_ia_results_skips_sparql(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+        $tfc->expects($this->never())->method('getSPARQL_TSV');
+
+        $http = $this->createMock(\HttpClientInterface::class);
+        $http->method('getJson')->willReturnCallback(function (string $_url) {
+            $r = new \stdClass();
+            $r->query = new \stdClass();
+            $r->query->categorymembers = [];
+            return $r;
+        });
+
+        $config = new \WikiStreamConfigWikiFlix();
+        $ws = new class($config, $tfc, $http) extends \WikiStream {
+            public array $capturedCommands = [];
+            protected function pushQuickStatements(array $commands): void
+            {
+                $this->capturedCommands = $commands;
+            }
+        };
+        $ws->import_commons_pd_films_via_p180();
+
+        $this->assertCount(0, $ws->capturedCommands);
+    }
+
     /**
      * @SuppressWarnings(PHPMD.ShortVariable)
      */

--- a/tests/unit/WikiStreamTest.php
+++ b/tests/unit/WikiStreamTest.php
@@ -908,4 +908,98 @@ final class WikiStreamTest extends TestCase
 
         $this->assertCount(0, $ws->capturedCommands);
     }
+
+    // ------------------------------------------------------------------
+    // C3: import_ia_curated_imdb_p724() walks the curated IA collections
+    // for items carrying an IMDb external-identifier, resolves the IMDb
+    // ID to a Wikidata Q-id via P345 (skipping items that already have
+    // P724), and queues a QuickStatements command to add the IA P724.
+    // ------------------------------------------------------------------
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    public function test_import_ia_curated_imdb_p724_emits_qs_for_resolved_imdb(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+
+        // SPARQL resolves IMDb -> Wikidata Q. tt0001 -> Q501, tt0002 -> Q502.
+        $tfc->method('getSPARQL_TSV')->willReturn([
+            ['q' => 'http://www.wikidata.org/entity/Q501', 'imdb' => 'tt0001'],
+            ['q' => 'http://www.wikidata.org/entity/Q502', 'imdb' => 'tt0002'],
+        ]);
+        $tfc->method('parseItemFromURL')->willReturnCallback(
+            fn(string $url) => preg_match('~Q\d+$~', $url, $m) ? $m[0] : ''
+        );
+
+        // HTTP: IA search returns 3 results in feature_films, 1 in silent_films, 0 in prelinger.
+        $http = $this->createMock(\HttpClientInterface::class);
+        $http->method('getJson')->willReturnCallback(function (string $url) {
+            $r = new \stdClass();
+            $r->response = new \stdClass();
+            if (str_contains($url, 'feature_films')) {
+                $r->response->docs = [
+                    (object) ['identifier' => 'ia-id-1', 'external-identifier' => 'urn:imdb:tt0001'],
+                    (object) ['identifier' => 'ia-id-2', 'external-identifier' => 'urn:imdb:tt0002'],
+                    (object) ['identifier' => 'ia-id-3', 'external-identifier' => 'urn:imdb:tt0003'], // unresolved
+                ];
+            } elseif (str_contains($url, 'silent_films')) {
+                $r->response->docs = [
+                    (object) ['identifier' => 'ia-id-1-dup', 'external-identifier' => 'urn:imdb:tt0001'], // dup IMDb
+                ];
+            } else {
+                $r->response->docs = [];
+            }
+            return $r;
+        });
+
+        $config = new \WikiStreamConfigWikiFlix();
+        $ws = new class($config, $tfc, $http) extends \WikiStream {
+            public array $capturedCommands = [];
+            protected function pushQuickStatements(array $commands): void
+            {
+                $this->capturedCommands = $commands;
+            }
+        };
+        $ws->import_ia_curated_imdb_p724();
+
+        $this->assertCount(2, $ws->capturedCommands, 'Two resolved IMDb IDs should yield two commands.');
+        $joined = implode("\n", $ws->capturedCommands);
+        $this->assertStringContainsString("Q501\tP724\t\"ia-id-1\"", $joined);
+        $this->assertStringContainsString("Q502\tP724\t\"ia-id-2\"", $joined);
+        $this->assertStringNotContainsString('ia-id-3', $joined, 'Unresolved IMDb tt0003 yields no command.');
+    }
+
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    public function test_import_ia_curated_imdb_p724_no_ia_results_skips_sparql(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+        $tfc->expects($this->never())->method('getSPARQL_TSV');
+
+        $http = $this->createMock(\HttpClientInterface::class);
+        $http->method('getJson')->willReturnCallback(function (string $_url) {
+            $r = new \stdClass();
+            $r->response = new \stdClass();
+            $r->response->docs = [];
+            return $r;
+        });
+
+        $config = new \WikiStreamConfigWikiFlix();
+        $ws = new class($config, $tfc, $http) extends \WikiStream {
+            public array $capturedCommands = [];
+            protected function pushQuickStatements(array $commands): void
+            {
+                $this->capturedCommands = $commands;
+            }
+        };
+        $ws->import_ia_curated_imdb_p724();
+
+        $this->assertCount(0, $ws->capturedCommands);
+    }
 }

--- a/tests/unit/WikiStreamTest.php
+++ b/tests/unit/WikiStreamTest.php
@@ -902,6 +902,9 @@ final class WikiStreamTest extends TestCase
         $this->assertSame(\WikiStream::PRE_1900_PD_PER_RUN, count($ws->capturedCommands));
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
     public function test_annotate_pre_1900_public_domain_no_candidates_skips_qs(): void
     {
         $db = $this->makeFakeDb();

--- a/tests/unit/WikiStreamTest.php
+++ b/tests/unit/WikiStreamTest.php
@@ -826,4 +826,86 @@ final class WikiStreamTest extends TestCase
 
         $ws->import_commons_video_minutes();
     }
+
+    // ------------------------------------------------------------------
+    // C1: annotate_pre_1900_public_domain() emits QuickStatements
+    // commands setting P6216=Q19652 (public domain) with the
+    // determination-method qualifier P459=Q47246828 ("published more
+    // than 95 years ago") for films dated before 1900 that have no
+    // existing P6216 statement. Hard-bounded by a per-run cap.
+    // ------------------------------------------------------------------
+
+    /**
+     * Build a recording WikiStream that captures pushQuickStatements()
+     * arguments instead of pushing them.
+     *
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
+    private function makeQsCapturingWikiStream(\ToolforgeCommon $tfc): object
+    {
+        $config = new \WikiStreamConfigWikiFlix();
+        return new class($config, $tfc, null) extends \WikiStream {
+            public array $capturedCommands = [];
+            protected function pushQuickStatements(array $commands): void
+            {
+                $this->capturedCommands = $commands;
+            }
+        };
+    }
+
+    public function test_annotate_pre_1900_public_domain_emits_correct_qs_shape(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+        $tfc->method('getSPARQL_TSV')->willReturn([
+            ['q' => 'http://www.wikidata.org/entity/Q1001'],
+            ['q' => 'http://www.wikidata.org/entity/Q1002'],
+        ]);
+        $tfc->method('parseItemFromURL')->willReturnCallback(
+            fn(string $url) => preg_match('~Q\d+$~', $url, $m) ? $m[0] : ''
+        );
+
+        $ws = $this->makeQsCapturingWikiStream($tfc);
+        $ws->annotate_pre_1900_public_domain();
+
+        $this->assertCount(2, $ws->capturedCommands);
+        $joined = implode("\n", $ws->capturedCommands);
+        // Each line is: "Q<id>\tP6216\tQ19652\tP459\tQ47246828\t/* comment */"
+        $this->assertStringContainsString("Q1001\tP6216\tQ19652\tP459\tQ47246828", $joined);
+        $this->assertStringContainsString("Q1002\tP6216\tQ19652\tP459\tQ47246828", $joined);
+    }
+
+    public function test_annotate_pre_1900_public_domain_caps_per_run(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+        $rows = [];
+        for ($q = 1; $q <= 200; $q++) {
+            $rows[] = ['q' => "http://www.wikidata.org/entity/Q{$q}"];
+        }
+        $tfc->method('getSPARQL_TSV')->willReturn($rows);
+        $tfc->method('parseItemFromURL')->willReturnCallback(
+            fn(string $url) => preg_match('~Q\d+$~', $url, $m) ? $m[0] : ''
+        );
+
+        $ws = $this->makeQsCapturingWikiStream($tfc);
+        $ws->annotate_pre_1900_public_domain();
+
+        $this->assertSame(\WikiStream::PRE_1900_PD_PER_RUN, count($ws->capturedCommands));
+    }
+
+    public function test_annotate_pre_1900_public_domain_no_candidates_skips_qs(): void
+    {
+        $db = $this->makeFakeDb();
+        $tfc = $this->createMock(\ToolforgeCommon::class);
+        $tfc->method('openDBtool')->willReturn($db);
+        $tfc->method('getSPARQL_TSV')->willReturn([]);
+
+        $ws = $this->makeQsCapturingWikiStream($tfc);
+        $ws->annotate_pre_1900_public_domain();
+
+        $this->assertCount(0, $ws->capturedCommands);
+    }
 }

--- a/tests/unit/WikiStreamTest.php
+++ b/tests/unit/WikiStreamTest.php
@@ -879,6 +879,9 @@ final class WikiStreamTest extends TestCase
         $this->assertStringContainsString("Q1002\tP6216\tQ19652\tP459\tQ47246828", $joined);
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
     public function test_annotate_pre_1900_public_domain_caps_per_run(): void
     {
         $db = $this->makeFakeDb();

--- a/tests/unit/WikiStreamTest.php
+++ b/tests/unit/WikiStreamTest.php
@@ -853,6 +853,9 @@ final class WikiStreamTest extends TestCase
         };
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.ShortVariable)
+     */
     public function test_annotate_pre_1900_public_domain_emits_correct_qs_shape(): void
     {
         $db = $this->makeFakeDb();
@@ -939,18 +942,18 @@ final class WikiStreamTest extends TestCase
         $http->method('getJson')->willReturnCallback(function (string $url) {
             $r = new \stdClass();
             $r->response = new \stdClass();
+            $r->response->docs = [];
             if (str_contains($url, 'feature_films')) {
                 $r->response->docs = [
                     (object) ['identifier' => 'ia-id-1', 'external-identifier' => 'urn:imdb:tt0001'],
                     (object) ['identifier' => 'ia-id-2', 'external-identifier' => 'urn:imdb:tt0002'],
                     (object) ['identifier' => 'ia-id-3', 'external-identifier' => 'urn:imdb:tt0003'], // unresolved
                 ];
-            } elseif (str_contains($url, 'silent_films')) {
+            }
+            if (str_contains($url, 'silent_films')) {
                 $r->response->docs = [
                     (object) ['identifier' => 'ia-id-1-dup', 'external-identifier' => 'urn:imdb:tt0001'], // dup IMDb
                 ];
-            } else {
-                $r->response->docs = [];
             }
             return $r;
         });
@@ -1072,7 +1075,7 @@ final class WikiStreamTest extends TestCase
         $tfc->expects($this->never())->method('getSPARQL_TSV');
 
         $http = $this->createMock(\HttpClientInterface::class);
-        $http->method('getJson')->willReturnCallback(function (string $_url) {
+        $http->method('getJson')->willReturnCallback(function () {
             $r = new \stdClass();
             $r->query = new \stdClass();
             $r->query->categorymembers = [];
@@ -1103,7 +1106,7 @@ final class WikiStreamTest extends TestCase
         $tfc->expects($this->never())->method('getSPARQL_TSV');
 
         $http = $this->createMock(\HttpClientInterface::class);
-        $http->method('getJson')->willReturnCallback(function (string $_url) {
+        $http->method('getJson')->willReturnCallback(function () {
             $r = new \stdClass();
             $r->response = new \stdClass();
             $r->response->docs = [];


### PR DESCRIPTION
## Summary

Third of three PRs from the WikiFlix \"find more eligible movies\" audit. All three commits add Wikidata-writing bots that enrich existing items so the regular ingestion pipeline picks them up on subsequent cron runs.

- **C1** — \`annotate_pre_1900_public_domain()\`. Films dated \`wdt:P577 < 1900\` with no P6216 statement get \`P6216 = Q19652\` (public domain) with the determination-method qualifier \`P459 = Q47246828\` (\"published more than 95 years ago\"). Pre-1900 films are PD globally; the qualifier matches the convention used on 32,954 existing film statements. Live SPARQL: ~86 candidate films, capped at 100 per run, so backlog usually clears in one run.
- **C3** — \`import_ia_curated_imdb_p724()\`. The complement to PR-2's A5: A5 takes Wikidata films with a P724 IA statement and verifies the IA collection; C3 walks IA's curated collections directly (\`feature_films\`, \`silent_films\`, \`prelinger\`), pulls IMDb external-identifiers, resolves them to Wikidata items lacking P724 via SPARQL on P345, and queues QS to add P724. Capped at 100 IA candidates per run. Live IA: ~2,114 \`feature_films\` items with IMDb IDs alone — backlog clears over many cron runs.
- **C2** — \`import_commons_pd_films_via_p180()\`. Walks the \`Films in the public domain\` Commons category, restricts to video files (.webm/.ogv/.ogg/.mp4), fetches each file's M-entity P180 (depicts) claim. When P180 points to a single Wikidata film item that has no P10 statement at all, queues QS to add P10 with the Commons filename.

## Constraint: item-file connection correctness (C2)

You asked specifically that C2 only land if the item-file connection is reliable. Implementation guards:

- **P180-linked only.** Files without a P180 claim are skipped. Title-matching is not used.
- **Single P180 only.** Files with multiple P180 values are skipped — we can't pick one.
- **Video extension filter.** JPG screenshots in PD-films categories don't accidentally become P10 statements.
- **Target verified as a film.** A SPARQL pass confirms the P180 target is \`P31/P279* Q11424\`.
- **Target has no existing P10.** Even adding a second P10 to a film with one already is left for humans.

## Constraint compliance

- **Don't exclude currently-included films.** All three bots are additive — they push new statements to Wikidata that the cron pipeline ingests on the next pass. None remove or alter existing data. ✓
- **No CC-*-ND ingestion.** None of these touch licence handling. ✓

## Reusable infrastructure

Shared helpers extracted on \`WikiStream\` (already present from PR-2 / created here as needed):
- \`loadWikidataItemList(\$qs)\` — factory tests can override.
- \`pushQuickStatements(\$commands)\` — no-ops when QS isn't installed (dev/test).

## Test plan

- [x] \`vendor/bin/phpunit\` — 133 tests, 247 assertions, all green
- [x] **C1**: QS shape (P6216 + P459 qualifier), per-run cap, no-candidates fast path
- [x] **C3**: IA search + IMDb→Wikidata resolution, unresolved IMDb IDs skipped, dup IMDb across collections deduped, no-IA-results skips SPARQL
- [x] **C2**: P180-linked video → P10, non-video files filtered, P180 target not a film skipped, empty category short-circuits before SPARQL
- [x] Live API validation for C1 SPARQL and C3 IA search shape
- [ ] After merge: one cron run of \`scripts/update.php\` to confirm QS edits land for each bot